### PR TITLE
Added dynamic title changes for easier history navigation

### DIFF
--- a/sample-slideshow.html
+++ b/sample-slideshow.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 
-<header id="intro" class="slide">
+<header id="intro" class="slide" title="CSSS: A brief introduction">
 	<h1>
 		<object data="logo.svg" width="100%" type="image/svg+xml">
 			<img src="logo.png" alt="CSSS: CSS-based SlideShow System" />
@@ -19,7 +19,7 @@
 	<p class="attribution">By Lea Verou</p>
 </header>
 
-<div class="slide">
+<div class="slide" title="CSSS: What is it?">
 	<h2>What is it?</h2>
 	<p>A simple framework for building presentations with modern web standards</p>
 	<ul>
@@ -29,7 +29,7 @@
 	</ul>
 </div>
 
-<div class="slide">
+<div class="slide" title="CSSS: History">
 	<h2>History</h2>
 	<ul>
 		<li class="delayed">I had to create a presentation for my talk at <a href="http://front-trends.com">Front Trends 2010</a></li>
@@ -40,7 +40,7 @@
 	</ul>
 </div>
 
-<div class="slide">
+<div class="slide" title="CSSS: What about S5?">
 	<h2>What about S5?</h2>
 	<ul>
 		<li class="delayed">I found out about <a href="http://meyerweb.com/eric/tools/s5/">S5</a> afterwards, via <a href="http://tantek.com">Tantek Çelik</a></li>
@@ -51,7 +51,7 @@
 	</ul>
 </div>
 
-<div class="slide" id="navigation">
+<div class="slide" id="navigation" title="CSSS: Navigation">
 	<h2>Navigation</h2>
 	<ul>
 		<li>→ or ↓ to advance to the next slide or incrementally displayed item</li>
@@ -65,7 +65,7 @@
 	<p>* Ctrl or Shift actually. Only Shift works in Opera.</p>
 </div>
 
-<div class="slide" id="features">
+<div class="slide" id="features" title="CSSS: Features">
 	<h2>Features</h2>
 	<ul>
 		<li class="delayed">IDs are dynamically assigned by JavaScript&hellip;</li>
@@ -75,7 +75,7 @@
 	</ul>
 </div>
 
-<div class="slide">
+<div class="slide" title="CSSS: Drawbacks">
 	<h2>Drawbacks</h2>
 	<ul>
 		<li>Only supports Firefox 3.6+, the latest Chrome/Safari or Opera 10.60+. Why?
@@ -89,7 +89,7 @@
 	</ul>
 </div>
 
-<div class="slide">
+<div class="slide" title="CSSS: The End">
 	<h2>Thank you!</h2>
 	<p>Get it from <a href="http://github.com/LeaVerou/CSSS">http://github.com/LeaVerou/CSSS</a>
 	<p>Credits:</p>

--- a/slideshow.js
+++ b/slideshow.js
@@ -221,7 +221,7 @@ SlideShow.prototype = {
 			
 			slide = this.slides[this.slide];
 			location.hash = '#' + slide.id;
-			
+			document.title = slide.title;
 		}
 		// Argument is a slide id
 		else if(which + '' === which) {
@@ -230,6 +230,7 @@ SlideShow.prototype = {
 			if(slide) {
 				this.slide = this.slides.indexOf(slide);
 				location.hash = '#' + which;
+        document.title = slide.title;
 			}
 		}
 		


### PR DESCRIPTION
Really tiny patch, title is defined in slide div as `title="<title>"` and inserted with document.title. As a magic bonus, the browsers display the title in the cursor tooltip on the thumbnail view on hover and on regular view also. Really helps navigating through big presentations using right click on the back button or long-click-hold (at least on Chrome). Browsers keep track of hash + title changes and merge them into one history entry making navigation super easy. I updated the example.html also with the new feature.
