### PR TITLE
Added page up and page down keyboard shortcuts (previous/next)

### DIFF
--- a/slideshow.js
+++ b/slideshow.js
@@ -175,11 +175,17 @@ var self = window.SlideShow = function(container, slide) {
 	*/
 	document.addEventListener('keydown', function(evt) {
 		if(evt.target === body || evt.target === body.parentNode || evt.altKey) {
-			if(evt.keyCode >= 35 && evt.keyCode <= 40) {
+			if(evt.keyCode >= 33 && evt.keyCode <= 40) {
 				evt.preventDefault();
 			}
 
 			switch(evt.keyCode) {
+				case 33: //page up
+					me.previous();
+					break;
+				case 34: //page down
+					me.next();
+					break;
 				case 35: // end
 					me.end();
 					break;


### PR DESCRIPTION
Thought it might be nice to have a one-click option for previous/next slide.  May not work quite right in Safari, but should work in Firefox, Chrome, and Opera.  I realize long slides will require mouse scrolling, but then again people using slides longer than one screen length deserve to have to use the mouse anyway :)
