### PR TITLE
PageUp PageDown additions (let's see if it's right this time)

### DIFF
--- a/slideshow.js
+++ b/slideshow.js
@@ -175,11 +175,17 @@ var self = window.SlideShow = function(container, slide) {
 	*/
 	document.addEventListener('keydown', function(evt) {
 		if(evt.target === body || evt.target === body.parentNode || evt.altKey) {
-			if(evt.keyCode >= 35 && evt.keyCode <= 40) {
+			if(evt.keyCode >= 33 && evt.keyCode <= 40) {
 				evt.preventDefault();
 			}
 
 			switch(evt.keyCode) {
+				case 33: //page up
+					me.previous();
+					break;
+				case 34: //page down
+					me.next();
+					break;
 				case 35: // end
 					me.end();
 					break;


### PR DESCRIPTION
Added PageUp and PageDown keyboard shortcuts to emulate CTRL+Up and CTRL+Down Arrow options for navigation between previous/next slides.  Due to the use of 'keydown' and keycodes, support should be full in all major browsers.
