### PR TITLE
[live-demo] Don't add notes if there is none

### DIFF
--- a/plugins/live-demo/live-demo.js
+++ b/plugins/live-demo/live-demo.js
@@ -89,7 +89,10 @@ export default class LiveDemo {
 		});
 
 		if (!this.minimal) {
-			this.controls.append($("details.notes", this.container));
+			let notes = $("details.notes", this.container);
+			if (notes) {
+				this.controls.append(notes);
+			}
 		}
 
 		if (!this.isolated) {


### PR DESCRIPTION
For now, we get this (see https://inspirejs.org/#livedemo)

<img width="700" alt="image" src="https://github.com/LeaVerou/inspire.js/assets/9166277/05786d5e-afc0-4166-96ea-33cc117dfff2">

This PR fixes it.

**UPDATE:** [The fixed demo](https://deploy-preview-163--inspirejs.netlify.app/#livedemo)
