### PR TITLE
Fix typo: Npm package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ import Inspire from "https://inspirejs.org/inspire.mjs";
 ### NPM
 
 ```sh
-npm install inspirejs
+npm install inspirejs.org
 ```
 
 then


### PR DESCRIPTION
hi, i noticed that
```npm i inspirejs``` didn't work because
https://www.npmjs.com/package/inspirejs.org

this PR shall fix the confusion for the next person:)