### PR TITLE
[live-demo] Plugin styles should be more specific than default styles (defined in `style/partials/code.css`)

### DIFF
--- a/plugins/live-demo/plugin.css
+++ b/plugins/live-demo/plugin.css
@@ -1,4 +1,4 @@
-:where(.live-demo) {
+.live-demo {
 	&:where(:not(.minimal)) {
 		background: var(--color-neutral-95);
 		color: canvastext;


### PR DESCRIPTION
This PR addresses the issue of low text contrast on live demo slides (when projecting them). Turns out it's a specificity issue: text color should be `canvas` https://github.com/LeaVerou/inspire.js/blob/2ede9e5b8aca57c252cefa1d218b153dc3ac15ff/plugins/live-demo/plugin.css#L13 instead of the inherited one https://github.com/LeaVerou/inspire.js/blob/2ede9e5b8aca57c252cefa1d218b153dc3ac15ff/style/partials/code.css#L5



**Before**

<img width="745" alt="image" src="https://github.com/user-attachments/assets/e792e167-d53f-4572-8667-e2d3bc72a73c" />

**After**

<img width="745" alt="image" src="https://github.com/user-attachments/assets/3acb92e2-abc1-47bb-9458-12fa10f560d1" />
