### PR TITLE
[markdown] Render text with headings as blocks regardless

### DIFF
--- a/plugins/markdown/plugin.js
+++ b/plugins/markdown/plugin.js
@@ -47,7 +47,8 @@ function renderCode(code) {
 		code = code.replace(new RegExp("^" + indent, "gm"), "");
 	}
 
-	return /\r?\n/.test(code.trim())? md.render(code) : md.renderInline(code);
+	// Text chunks with headings should be rendered as block markdown regardless
+	return /\r?\n|^\#/.test(code.trim())? md.render(code) : md.renderInline(code);
 }
 
 function render(e) {


### PR DESCRIPTION
Otherwise, if the markdown is broken with a tag, something like `## Foo` will be rendered using `mdInline`.