### PR TITLE
Import @inspirejs/core/util for dynamically loaded plugins

### DIFF
--- a/inspire.mjs
+++ b/inspire.mjs
@@ -1,7 +1,9 @@
 // Meta package: the one-install bundle of Inspire.js.
-// Imports the core engine (which auto-initializes) and the official plugins
-// (which attach to Inspire and autoload on demand), then re-exports the API.
+// Imports the core engine (which auto-initializes) and its subpath exports
+// needed by plugins at runtime, the official plugins (which attach to Inspire
+// and autoload on demand), then re-exports the API.
 import Inspire from "@inspirejs/core";
+import "@inspirejs/core/util";
 import "@inspirejs/plugins";
 
 export default Inspire;


### PR DESCRIPTION
## Summary
- Plugins import `@inspirejs/core/util` at runtime but are loaded dynamically, so the specifier isn't discovered by static import tracing (e.g. nudeps/JSPM)
- The meta package is the right layer to declare this runtime dependency

## Test plan
- [x] `npm install inspirejs.org` in a fresh project with nudeps
- [x] Verify `@inspirejs/core/util` appears in the generated import map
- [x] Verify plugins load without errors in the browser

### How it was tested
All three packages (`@inspirejs/core`, `@inspirejs/plugins`, `inspirejs.org`) were published to a local Verdaccio registry. Demo was clean-installed from Verdaccio (`rm -rf node_modules package-lock.json .nudeps client_modules && npm install --registry http://localhost:4873`), nudeps regenerated from scratch — produced 5 import map entries including `@inspirejs/core/util`. Slide deck loaded in browser with zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)