### PR TITLE
Drop the @inspirejs/core/util workaround

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,5 @@
 // Meta package: the one-install bundle of Inspire.js.
-// Imports the core engine (which auto-initializes) and its subpath exports
-// needed by plugins at runtime, the official plugins (which attach to Inspire
-// and autoload on demand), then re-exports the core object.
+// Imports the core engine (which auto-initializes) and the official plugins
+// (which attach to Inspire and autoload on demand), then re-exports the core object.
 export { default } from "@inspirejs/core";
-import "@inspirejs/core/util"; // workaround for plugins
 import "@inspirejs/plugins";


### PR DESCRIPTION
## What
The meta package no longer imports `@inspirejs/core/util` explicitly.

## Why
The plugins package now references each plugin file with a static loader, so import-map/bundler tooling traces the plugins' own dependencies — including `@inspirejs/core/util` — on their own. The explicit import is redundant.

Note: this relies on the plugins change shipping; the dependency floor is intentionally left at `^3`.

## Related PRs
Coordinated change across the repos:
- inspire-js/plugins#3 — static plugin loaders (makes deps traceable)
- inspire-js/core#2 — core honors the new `load` loader
- inspire-js/plugins#4 — markdown-it as a local dep

🤖 Generated with [Claude Code](https://claude.com/claude-code)
